### PR TITLE
Output message if target dir is actually a file

### DIFF
--- a/check_newest_file_age
+++ b/check_newest_file_age
@@ -304,6 +304,9 @@ do
         OK_FILE_COUNT=$(($OK_FILE_COUNT + 1))
       fi
     fi
+  elif [ -f "$full_path" ]; then
+    set_exit_status $STATE_UNKNOWN
+    OUTPUT="$OUTPUT ${dir}: Is a file (only directories are supported)"
   else
     set_exit_status $on_empty
     OUTPUT="$OUTPUT ${dir}: Does not exist"


### PR DESCRIPTION
Yes the argument is named `--dir`, but it took me a minute to figure out why the plugin was complaining that a file didn't exist when it clearly did. This PR adds a custom message indicating that files aren't supported if a file is passed as a `--dir` argument.