### PR TITLE
Bugfix: correctly check files with space in its filename

### DIFF
--- a/check_newest_file_age
+++ b/check_newest_file_age
@@ -260,6 +260,7 @@ do
     file_list=`ls -t $full_path 2> /dev/null`
     if [ $? -eq 0 ]; then
       # Cycle through files, looking for a checkable file.
+      IFS=$'\n'
       for next_file in $file_list
       do
         next_filepath=$full_path/$next_file


### PR DESCRIPTION
This plugin does not correctly check files with have spaces in the filename. To properly iterate over the filelist make sure that only newlines are used as separator.