### PR TITLE
Bugfix spaces in filenames

### DIFF
--- a/check_newest_file_age
+++ b/check_newest_file_age
@@ -278,9 +278,9 @@ do
           # stat doesn't work the same on Linux/Solaris vs. FreeBSD/Darwin, so
           # make adjustments here.
           if [ "$OS_DISTRO" = "Linux" ] || [ "$OS_DISTRO" = "SunOS" ]; then
-            st_ctime=`stat --printf=%Y ${next_filepath}`
+            st_ctime=`stat --printf=%Y "${next_filepath}"`
           else
-            eval $(stat -s ${next_filepath})
+            eval $(stat -s "${next_filepath}")
           fi
           FILE_AGE=$(($CURRENT_TIME - $st_ctime))
           FILE_AGE_UNITS=$(($FILE_AGE / $multiplier))


### PR DESCRIPTION
Sorry that I was only able to check it now. To make it properly work it is necessary to add quotes around the filename when calling to stat. (I guess my old version worked without that, because IFS was globally changed).

With this fix everything works as expected on my side now.